### PR TITLE
add basicAuthorizer service

### DIFF
--- a/authorization-service/.gitignore
+++ b/authorization-service/.gitignore
@@ -1,0 +1,11 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless
+
+# Enviroment variables
+.env
+
+package-lock.json

--- a/authorization-service/basicAuthorizer.js
+++ b/authorization-service/basicAuthorizer.js
@@ -1,0 +1,47 @@
+/* eslint-disable dot-notation */
+const { EFFECT } = require("./constants");
+
+module.exports.basicAuthorizer = async (event) => {
+  console.log("event", event);
+
+  // https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-lambda-authorizer-output.html
+
+  // for REST API must generate a policy
+  const generatePolicyDocument = (effect, resource) => {
+    return {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Action: "execute-api:Invoke",
+          Effect: effect,
+          Resource: resource,
+        },
+      ],
+    };
+  };
+
+  const generateResponse = (principalId, effect, resourse) => {
+    return {
+      principalId, // The principal user identification associated with the token sent by the client.
+      policyDocument: generatePolicyDocument(effect, resourse),
+    };
+  };
+
+  //  if authorizer type token, no headers in event, just authorizationToken
+  const { authorizationToken, methodArn } = event;
+
+  if (!authorizationToken) {
+    throw new Error("No authorization header provided"); // 401, API Gateway does automatically
+  }
+
+  const principalId = "Test";
+
+  const response =
+    authorizationToken === process.env["Inga_Vishnivetskaia"]
+      ? generateResponse(principalId, EFFECT.Allow, methodArn)
+      : generateResponse(principalId, EFFECT.Deny, methodArn); // 403, API Gateway does automatically
+
+  console.log("response:", response);
+
+  return response;
+};

--- a/authorization-service/constants.js
+++ b/authorization-service/constants.js
@@ -1,0 +1,8 @@
+const EFFECT = {
+  Allow: "Allow",
+  Deny: "Deny",
+};
+
+module.exports = {
+  EFFECT,
+};

--- a/authorization-service/package.json
+++ b/authorization-service/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "authorization-service",
+  "version": "1.0.0",
+  "description": "",
+  "main": "basicAuthorizer.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "serverless-dotenv-plugin": "^6.0.0"
+  }
+}

--- a/authorization-service/serverless.yml
+++ b/authorization-service/serverless.yml
@@ -1,0 +1,24 @@
+service: authorization-service
+frameworkVersion: '3'
+
+provider:
+  name: aws
+  runtime: nodejs18.x
+  stage: dev
+  region: eu-west-1
+
+plugins:
+  - serverless-dotenv-plugin
+
+functions:
+  basicAuthorizer:
+    handler: basicAuthorizer.basicAuthorizer
+
+#    Define function environment variables here
+#    environment:
+#      variable2: value2
+
+#  Outputs:
+#     NewOutput:
+#       Description: "Description for the output"
+#       Value: "Some output value"

--- a/import-service/serverless.yml
+++ b/import-service/serverless.yml
@@ -44,7 +44,14 @@ functions:
           request:
             parameters:
               querystrings:
-                name: true
+                name: true          	
+          authorizer:
+            arn: arn:aws:lambda:eu-west-1:770955452549:function:authorization-service-dev-basicAuthorizer
+            # no caching:
+            resultTtlInSeconds: 0
+            # identitySource: method.request.header.Authorization
+            # identityValidationExpression: someRegex
+            type: token
   importFileParser:
     handler: handlers/importFileParser.importFileParser
     events:


### PR DESCRIPTION
- authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file
- Import Service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
- Client application is updated to send "Authorization: Basic authorization_token" header on import. Client should get authorization_token value from browser localStorage